### PR TITLE
Fix markdown linting errors and SARIF upload issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,19 @@ jobs:
           output: 'trivy-qbittorrent-results.sarif'
           severity: 'CRITICAL,HIGH'
 
-      - name: Upload Trivy results to GitHub Security tab
+      - name: Upload Trivy Gluetun results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
-          sarif_file: '.'
+          sarif_file: 'trivy-gluetun-results.sarif'
+          category: 'trivy-gluetun'
+
+      - name: Upload Trivy qBittorrent results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-qbittorrent-results.sarif'
+          category: 'trivy-qbittorrent'
 
       - name: Run Trivy on repository
         uses: aquasecurity/trivy-action@master

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document describes the architecture of the qBittorrent + ProtonVPN Docker i
 
 ## System Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                        Docker Host                               │
 │                                                                   │
@@ -110,7 +110,7 @@ This document describes the architecture of the qBittorrent + ProtonVPN Docker i
 
 ### Network Segmentation
 
-```
+```text
 VPN Network (172.20.0.0/16)
 ├── Gluetun (172.20.0.10)
 └── qBittorrent (shares Gluetun network namespace)
@@ -174,7 +174,7 @@ Monitoring Network (172.21.0.0/16)
 
 ### Persistent Storage
 
-```
+```text
 Named Volumes:
 ├── gluetun-config         (VPN configurations)
 ├── qbittorrent-config     (qBittorrent settings)
@@ -202,7 +202,7 @@ Bind Mounts:
 
 ### Infrastructure as Code
 
-```
+```text
 Project Structure:
 ├── docker-compose.yml          (Service definitions)
 ├── Makefile                    (Operations automation)

--- a/docs/QBITTORRENT_SETUP.md
+++ b/docs/QBITTORRENT_SETUP.md
@@ -20,15 +20,15 @@ docker logs qbittorrent 2>&1 | grep -oP '(?<=password is: ).*'
 
 ### Login
 
-1. Open http://localhost:8080
-2. Username: `admin`
-3. Password: `[temporary password from above]`
+1. Open <http://localhost:8080>
+1. Username: `admin`
+1. Password: `[temporary password from above]`
 
 ### ⚠️ CRITICAL: Set Permanent Password
 
 1. Go to **Tools** → **Options** → **Web UI**
-2. Set a new password under "Authentication"
-3. Click **Save**
+1. Set a new password under "Authentication"
+1. Click **Save**
 
 **If you skip this:** You'll need to retrieve the temp password after every container restart!
 
@@ -37,10 +37,10 @@ docker logs qbittorrent 2>&1 | grep -oP '(?<=password is: ).*'
 For automatic port forwarding to work, you MUST enable localhost bypass:
 
 1. **Tools** → **Options** → **Web UI**
-2. Scroll to "**Security**" section
-3. ✅ **Enable** "Bypass authentication for clients on localhost"
-4. Click **Save**
-5. Restart qBittorrent: `docker restart qbittorrent`
+1. Scroll to "**Security**" section
+1. ✅ **Enable** "Bypass authentication for clients on localhost"
+1. Click **Save**
+1. Restart qBittorrent: `docker restart qbittorrent`
 
 **Without this:** Port sync mod will fail with authentication errors!
 
@@ -64,13 +64,14 @@ Restart: `make restart`
 
 ```bash
 docker inspect gluetun | grep IPAddress
-# Access via: http://[IP]:8080
+# Access via: <http://[IP]:8080>
 ```
 
 ### Port Sync Errors
 
 **Error:**
-```
+
+```text
 [GSP] - [ERROR] The "Bypass authentication for clients on localhost" setting is not set.
 ```
 
@@ -108,7 +109,7 @@ docker logs qbittorrent | grep GSP | tail -10
 | Action | Command |
 |--------|---------|
 | Get temp password | `docker logs qbittorrent 2>&1 \| grep "temporary password"` |
-| Access Web UI | http://localhost:8080 |
+| Access Web UI | <http://localhost:8080> |
 | Restart qBittorrent | `docker restart qbittorrent` |
 | View logs | `docker logs qbittorrent` |
 | Edit config | `docker exec -it qbittorrent nano /config/qBittorrent/qBittorrent.conf` |

--- a/docs/adr/002-network-architecture.md
+++ b/docs/adr/002-network-architecture.md
@@ -35,7 +35,7 @@ Using `network_mode: service:gluetun`:
 
 ## Network Topology
 
-```
+```text
 ┌─────────────────────────────────────────────┐
 │           Docker Host                        │
 │                                              │

--- a/docs/adr/003-infrastructure-as-code.md
+++ b/docs/adr/003-infrastructure-as-code.md
@@ -66,6 +66,7 @@ services: [all services with full config]
 ```
 
 ### Operations (Makefile)
+
 ```makefile
 make init      # Initialize project
 make up        # Start services
@@ -77,7 +78,8 @@ make monitoring # Open dashboards
 ```
 
 ### Automation (scripts/)
-```
+
+```text
 scripts/
 ├── backup.sh   # Backup procedure
 └── restore.sh  # Restore procedure
@@ -152,7 +154,7 @@ scripts/
 
 ## File Structure
 
-```
+```text
 qbittorrent-protonvpn-docker/
 ├── docker-compose.yml          # Service definitions
 ├── Makefile                    # Operations automation


### PR DESCRIPTION
Markdown linting fixes (MD034, MD029, MD040):
- Added language specifiers to code blocks (text, bash, yaml, makefile)
- Wrapped bare URLs in angle brackets
- Changed ordered lists to use consistent '1.' prefix
- Added blank lines before/after code blocks

Files fixed:
- docs/ARCHITECTURE.md
- docs/QBITTORRENT_SETUP.md
- docs/adr/002-network-architecture.md
- docs/adr/003-infrastructure-as-code.md

SARIF upload fix:
- Split single upload step into two separate uploads
- Added category labels to distinguish Gluetun and qBittorrent results
- Prevents CodeQL from trying to upload multiple SARIF files together

Resolves jobs 60691596918 and 60691601349